### PR TITLE
Fix path to executable

### DIFF
--- a/stripe.json
+++ b/stripe.json
@@ -4,7 +4,7 @@
         "64bit": {
             "url": "https://github.com/stripe/stripe-cli/releases/download/v1.3.9/stripe_1.3.9_windows_x86_64.zip",
             "bin": [
-                "stripe.exe.exe"
+                "stripe.exe"
             ],
             "hash": "a3167e0849d526700eafdf85b065ae3894636d25c31edb28cec8e700fd5fe96b"
         }


### PR DESCRIPTION
The path inside the ZIP file is `stripe.exe`, not `stripe.exe.exe`. The current faulty value causes the shim creation to fail, and means that stripe will not be correctly installed or accessible. This fixes the path to the executable.